### PR TITLE
Adding more logging around cpuLimits

### DIFF
--- a/agent/api/task_windows.go
+++ b/agent/api/task_windows.go
@@ -49,6 +49,7 @@ func (task *Task) adjustForPlatform(cfg *config.Config) {
 	platformFields := platformFields{
 		cpuUnbounded: cfg.PlatformVariables.CPUUnbounded,
 	}
+	seelog.Warnf("CoveoDebug: cpuUnbounded in func adjustForPlatform is %s", cpuUnbounded)
 	task.platformFields = platformFields
 }
 
@@ -80,7 +81,7 @@ func (task *Task) platformHostConfigOverride(hostConfig *docker.HostConfig) erro
 	task.overrideDefaultMemorySwappiness(hostConfig)
 	// Convert the CPUShares to CPUPercent
 	hostConfig.CPUPercent = hostConfig.CPUShares * percentageFactor / int64(cpuShareScaleFactor)
-	seelog.Warnf("hostConfig.CPUPercent is set to %s and hostConfig.CPUShares is %s", hostConfig.CPUPercent, hostConfig.CPUShares)
+	seelog.Warnf("CoveoDebug: hostConfig.CPUPercent is set to %s and hostConfig.CPUShares is %s", hostConfig.CPUPercent, hostConfig.CPUShares)
 	if hostConfig.CPUPercent == 0 && hostConfig.CPUShares != 0 {
 		// if CPU percent is too low, we set it to the minimum(linux and some windows tasks).
 		// if the CPU is explicitly set to zero or not set at all, and CPU unbounded
@@ -113,10 +114,11 @@ func (task *Task) overrideDefaultMemorySwappiness(hostConfig *docker.HostConfig)
 // want.  Instead, we convert 0 to 2 to be closer to expected behavior. The
 // reason for 2 over 1 is that 1 is an invalid value (Linux's choice, not Docker's).
 func (task *Task) dockerCPUShares(containerCPU uint) int64 {
+	seelog.Warnf("CoveoDebug: func dockerCPUShares has containerCPU %s value and task.platformFields.cpuUnbounded is %s. ", containerCPU, task.platformFields.cpuUnbounded)
 	if containerCPU <= 1 && !task.platformFields.cpuUnbounded {
 		seelog.Warnf(
-			"Converting CPU shares to allowed minimum of 2 for task arn: [%s] and cpu shares: %d",
-			task.Arn, containerCPU)
+			"Converting CPU shares to allowed minimum of 2 for task arn: [%s] and cpu shares: %d. cpuUnbounded is %s",
+			task.Arn, containerCPU, task.platformFields.cpuUnbounded)
 		return 2
 	}
 	return int64(containerCPU)

--- a/agent/config/config_windows.go
+++ b/agent/config/config_windows.go
@@ -114,6 +114,8 @@ func (cfg *Config) platformOverrides() {
 		CPUUnbounded: cpuUnbounded,
 	}
 	cfg.PlatformVariables = platformVariables
+	seelog.Warnf("CoveoDebug: func platformOverrides has cfg.PlatformVariables %s config", cfg.PlatformVariables)
+
 }
 
 // platformString returns platform-specific config data that can be serialized

--- a/agent/version/version.go
+++ b/agent/version/version.go
@@ -22,7 +22,7 @@ package version
 // repository. Only the 'Version' const should change in checked-in source code
 
 // Version is the version of the Agent
-const Version = "1.18.0-coveo.4"
+const Version = "1.18.0-coveo.5"
 
 // GitDirty indicates the cleanliness of the git repo when this agent was built
 const GitDirty = true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [ ] Builds on Linux (`make release`)
- [ ] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [ ] Unit tests on Linux (`make test`) pass
- [ ] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [ ] Integration tests on Linux (`make run-integ-tests`) pass
- [ ] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [ ] Functional tests on Linux (`make run-functional-tests`) pass
- [ ] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
